### PR TITLE
set up initial structure with gitignore and package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+.env

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "backEndCapstone",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "nodemon app.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mozecode/dose.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bcrypt-nodejs": "0.0.3",
+    "body-parser": "^1.18.2",
+    "bootstrap": "^4.0.0-beta",
+    "dotenv": "^4.0.0",
+    "express": "^4.16.1",
+    "jquery": "^3.2.1",
+    "method-override": "^2.3.10",
+    "express-flash": "0.0.2",
+    "express-session": "^1.15.6",
+    "passport": "^0.4.0",
+    "passport-local": "^1.0.0",
+    "pg": "^7.3.0",
+    "pg-hstore": "^2.3.2",
+    "popper.js": "^1.12.5",
+    "pug": "^2.0.0-rc.4",
+    "sequelize": "^4.13.5"
+  },
+  "bugs": {
+    "url": "https://github.com/mozecode/dose/issues"
+  },
+  "homepage": "https://github.com/mozecode/dose#readme"
+}


### PR DESCRIPTION
I made the following changes:

- set up initial structure with gitignore and package.json

Reason:

- need to make sure that gitignore is in place to avoid pushing up node module files inadvertently, set up package json initial dependencies 



